### PR TITLE
【WIP】【Don't Merge】設定画面をどうにかしたい

### DIFF
--- a/iTunesArtworkiPhone.xcodeproj/project.pbxproj
+++ b/iTunesArtworkiPhone.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		69AACB041E9E2F0700443DBF /* ItemTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69AACB031E9E2F0700443DBF /* ItemTableViewCell.swift */; };
 		69AACB061E9E303700443DBF /* TableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69AACB051E9E303700443DBF /* TableViewController.swift */; };
 		69AACB081E9E49AA00443DBF /* WebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69AACB071E9E49AA00443DBF /* WebViewController.swift */; };
+		A558D0B61EAC53C7009BE780 /* SettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A558D0B51EAC53C7009BE780 /* SettingViewController.swift */; };
+		A558D0B81EAC5BEF009BE780 /* DeviceData.swift in Sources */ = {isa = PBXBuildFile; fileRef = A558D0B71EAC5BEF009BE780 /* DeviceData.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -45,6 +47,8 @@
 		69AACB031E9E2F0700443DBF /* ItemTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ItemTableViewCell.swift; sourceTree = "<group>"; };
 		69AACB051E9E303700443DBF /* TableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewController.swift; sourceTree = "<group>"; };
 		69AACB071E9E49AA00443DBF /* WebViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebViewController.swift; sourceTree = "<group>"; };
+		A558D0B51EAC53C7009BE780 /* SettingViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingViewController.swift; sourceTree = "<group>"; };
+		A558D0B71EAC5BEF009BE780 /* DeviceData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceData.swift; sourceTree = "<group>"; };
 		DA24D69DC7FF569464CD3F12 /* Pods-iTunesArtworkiPhone.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-iTunesArtworkiPhone.release.xcconfig"; path = "Pods/Target Support Files/Pods-iTunesArtworkiPhone/Pods-iTunesArtworkiPhone.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -72,6 +76,7 @@
 		690558081EA35A8400186D14 /* Setting */ = {
 			isa = PBXGroup;
 			children = (
+				A558D0B51EAC53C7009BE780 /* SettingViewController.swift */,
 				690558061EA35A6300186D14 /* SettingTableViewController.swift */,
 				690558091EA35AD900186D14 /* SettingCell.swift */,
 				6905580D1EA36CBC00186D14 /* SizeTableViewController.swift */,
@@ -127,6 +132,7 @@
 				690558081EA35A8400186D14 /* Setting */,
 				69AACB071E9E49AA00443DBF /* WebViewController.swift */,
 				699F0CE91E9E298700A3388F /* AppDelegate.swift */,
+				A558D0B71EAC5BEF009BE780 /* DeviceData.swift */,
 				699F0CF21E9E298700A3388F /* LaunchScreen.storyboard */,
 				699F0CF51E9E298700A3388F /* Info.plist */,
 				690558281EA856D600186D14 /* Images.xcassets */,
@@ -269,11 +275,13 @@
 				6905581E1EA79D7B00186D14 /* MovieCell.swift in Sources */,
 				6905581C1EA79D6000186D14 /* MovieViewController.swift in Sources */,
 				69AACB041E9E2F0700443DBF /* ItemTableViewCell.swift in Sources */,
+				A558D0B61EAC53C7009BE780 /* SettingViewController.swift in Sources */,
 				699F0CEA1E9E298700A3388F /* AppDelegate.swift in Sources */,
 				6905580A1EA35AD900186D14 /* SettingCell.swift in Sources */,
 				690558161EA6161800186D14 /* CountryCell.swift in Sources */,
 				69AACB061E9E303700443DBF /* TableViewController.swift in Sources */,
 				690558101EA36CD900186D14 /* SizeCell.swift in Sources */,
+				A558D0B81EAC5BEF009BE780 /* DeviceData.swift in Sources */,
 				6905580E1EA36CBC00186D14 /* SizeTableViewController.swift in Sources */,
 				690558181EA6162600186D14 /* CountryTableViewController.swift in Sources */,
 				69AACB081E9E49AA00443DBF /* WebViewController.swift in Sources */,

--- a/iTunesArtworkiPhone/Base.lproj/Main.storyboard
+++ b/iTunesArtworkiPhone/Base.lproj/Main.storyboard
@@ -186,55 +186,72 @@
             </objects>
             <point key="canvasLocation" x="1988" y="499"/>
         </scene>
-        <!--設定-->
-        <scene sceneID="DgN-qE-ZUL">
+        <!--Setting-->
+        <scene sceneID="6XI-OT-NgS">
             <objects>
-                <tableViewController title="設定" id="KiQ-RD-pnO" customClass="SettingTableViewController" customModule="iTunesArtworkiPhone" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="7GT-5u-IbY">
+                <viewController id="sER-PM-Kuw" customClass="SettingViewController" customModule="iTunesArtworkiPhone" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="Nrw-16-4IB"/>
+                        <viewControllerLayoutGuide type="bottom" id="ZeD-s0-L3j"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="hCh-zi-jjN">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="国" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XRs-cZ-yZB">
+                                <rect key="frame" x="52" y="72" width="17.5" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eQ6-cC-HQe">
+                                <rect key="frame" x="52" y="101" width="42" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="アートワークのサイズ" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tqb-j6-bZR">
+                                <rect key="frame" x="52" y="170" width="174" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qHl-9U-09D">
+                                <rect key="frame" x="52" y="199" width="42" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <pickerView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bsh-aY-7Ei">
+                                <rect key="frame" x="0.0" y="402" width="375" height="216"/>
+                            </pickerView>
+                        </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                        <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="settingCell" id="SxI-Sc-E2I" customClass="SettingCell" customModule="iTunesArtworkiPhone" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="28" width="375" height="44"/>
-                                <autoresizingMask key="autoresizingMask"/>
-                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="SxI-Sc-E2I" id="bPS-BC-6fU">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
-                                    <autoresizingMask key="autoresizingMask"/>
-                                    <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iLA-3F-MRC">
-                                            <rect key="frame" x="18" y="13" width="339" height="17.5"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                            <nil key="textColor"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                    </subviews>
-                                    <constraints>
-                                        <constraint firstAttribute="bottomMargin" secondItem="iLA-3F-MRC" secondAttribute="bottom" constant="5" id="74H-d6-czm"/>
-                                        <constraint firstAttribute="trailingMargin" secondItem="iLA-3F-MRC" secondAttribute="trailing" constant="10" id="JRY-ZP-xbV"/>
-                                        <constraint firstItem="iLA-3F-MRC" firstAttribute="top" secondItem="bPS-BC-6fU" secondAttribute="topMargin" constant="5" id="OY6-MH-Cog"/>
-                                        <constraint firstItem="iLA-3F-MRC" firstAttribute="leading" secondItem="bPS-BC-6fU" secondAttribute="leadingMargin" constant="10" id="ca2-it-zLZ"/>
-                                    </constraints>
-                                </tableViewCellContentView>
-                                <connections>
-                                    <outlet property="setLabel" destination="iLA-3F-MRC" id="0P3-46-mbH"/>
-                                </connections>
-                            </tableViewCell>
-                        </prototypes>
-                        <connections>
-                            <outlet property="dataSource" destination="KiQ-RD-pnO" id="okZ-2v-k6f"/>
-                            <outlet property="delegate" destination="KiQ-RD-pnO" id="ECL-bt-0uX"/>
-                        </connections>
-                    </tableView>
-                    <navigationItem key="navigationItem" title="Setting" id="0fB-6l-LG5"/>
+                        <constraints>
+                            <constraint firstItem="tqb-j6-bZR" firstAttribute="top" secondItem="eQ6-cC-HQe" secondAttribute="bottom" constant="48" id="4W9-LC-WK0"/>
+                            <constraint firstItem="XRs-cZ-yZB" firstAttribute="leading" secondItem="hCh-zi-jjN" secondAttribute="leading" constant="52" id="8Zk-88-wSi"/>
+                            <constraint firstItem="eQ6-cC-HQe" firstAttribute="top" secondItem="XRs-cZ-yZB" secondAttribute="bottom" constant="8" id="B2e-pN-nzJ"/>
+                            <constraint firstItem="ZeD-s0-L3j" firstAttribute="top" secondItem="bsh-aY-7Ei" secondAttribute="bottom" id="D8X-Hm-13i"/>
+                            <constraint firstAttribute="trailing" secondItem="bsh-aY-7Ei" secondAttribute="trailing" id="G6j-a0-exg"/>
+                            <constraint firstItem="qHl-9U-09D" firstAttribute="leading" secondItem="XRs-cZ-yZB" secondAttribute="leading" id="J5H-e1-J7r"/>
+                            <constraint firstItem="tqb-j6-bZR" firstAttribute="leading" secondItem="XRs-cZ-yZB" secondAttribute="leading" id="Nzh-fv-yKz"/>
+                            <constraint firstItem="XRs-cZ-yZB" firstAttribute="top" secondItem="Nrw-16-4IB" secondAttribute="bottom" constant="52" id="Yi8-RR-C3w"/>
+                            <constraint firstItem="eQ6-cC-HQe" firstAttribute="leading" secondItem="XRs-cZ-yZB" secondAttribute="leading" id="axd-nS-a7u"/>
+                            <constraint firstItem="qHl-9U-09D" firstAttribute="top" secondItem="tqb-j6-bZR" secondAttribute="bottom" constant="8" id="fYP-yg-2D2"/>
+                            <constraint firstItem="bsh-aY-7Ei" firstAttribute="leading" secondItem="hCh-zi-jjN" secondAttribute="leading" id="vAA-JX-zYn"/>
+                        </constraints>
+                    </view>
+                    <tabBarItem key="tabBarItem" title="Setting" image="settingIcon@x2" id="i7p-XW-alg"/>
+                    <navigationItem key="navigationItem" id="0eW-TW-OgD"/>
                     <connections>
-                        <segue destination="hqz-jK-cxE" kind="show" identifier="size" id="c4F-RT-3Fv"/>
-                        <segue destination="Mvs-3V-ShL" kind="show" identifier="country" id="zLZ-hU-nTj"/>
+                        <outlet property="artworkLabel" destination="qHl-9U-09D" id="7jS-IY-p1K"/>
+                        <outlet property="countryLabel" destination="eQ6-cC-HQe" id="JDk-hD-DJ6"/>
+                        <outlet property="dataSetPickerView" destination="bsh-aY-7Ei" id="4Cq-lz-MB9"/>
                     </connections>
-                </tableViewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="RYQ-z2-6cZ" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Xgm-Fc-vSa" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1031.2" y="-570.76461769115451"/>
+            <point key="canvasLocation" x="132" y="-566"/>
         </scene>
         <!--国を設定-->
         <scene sceneID="VTQ-oa-a7I">
@@ -377,31 +394,12 @@
                     <connections>
                         <segue destination="hgD-hj-xbl" kind="relationship" relationship="viewControllers" id="IMe-HI-VqQ"/>
                         <segue destination="iJ4-nc-V2N" kind="relationship" relationship="viewControllers" id="ZLn-gt-dMm"/>
-                        <segue destination="iR2-WC-fOa" kind="relationship" relationship="viewControllers" id="uEa-zi-ZHK"/>
+                        <segue destination="sER-PM-Kuw" kind="relationship" relationship="viewControllers" id="Q3j-jX-paL"/>
                     </connections>
                 </tabBarController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="jc1-5F-PuJ" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-815" y="499"/>
-        </scene>
-        <!--Setting-->
-        <scene sceneID="q08-OR-oLV">
-            <objects>
-                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="iR2-WC-fOa" sceneMemberID="viewController">
-                    <tabBarItem key="tabBarItem" title="Setting" image="settingIcon@x2" id="m8a-eT-Ddi"/>
-                    <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="u0W-75-vV6">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </navigationBar>
-                    <nil name="viewControllers"/>
-                    <connections>
-                        <segue destination="KiQ-RD-pnO" kind="relationship" relationship="rootViewController" id="Jqg-qh-zl2"/>
-                    </connections>
-                </navigationController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="eAn-3H-7qp" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="124" y="-571"/>
         </scene>
     </scenes>
     <resources>

--- a/iTunesArtworkiPhone/DeviceData.swift
+++ b/iTunesArtworkiPhone/DeviceData.swift
@@ -1,0 +1,35 @@
+//
+//  DeviceData.swift
+//  iTunesArtworkiPhone
+//
+//  Created by いちもつ青田 on 2017/04/23.
+//  Copyright © 2017年 piyo. All rights reserved.
+//
+
+import Foundation
+
+internal struct DeviceData {
+    
+    struct UserDefaultsKey {
+        static let imageSize = "size"
+        static let country = "country"
+    }
+    
+    static var imageSizeRawValue: Int {
+        get {
+            return UserDefaults.standard.integer(forKey: UserDefaultsKey.imageSize)
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: UserDefaultsKey.imageSize)
+        }
+    }
+    
+    static var countryRawValue: Int {
+        get {
+            return UserDefaults.standard.integer(forKey: UserDefaultsKey.country)
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: UserDefaultsKey.country)
+        }
+    }
+}

--- a/iTunesArtworkiPhone/SettingViewController.swift
+++ b/iTunesArtworkiPhone/SettingViewController.swift
@@ -1,0 +1,111 @@
+//
+//  SettingViewController.swift
+//  iTunesArtworkiPhone
+//
+//  Created by いちもつ青田 on 2017/04/23.
+//  Copyright © 2017年 piyo. All rights reserved.
+//
+
+import UIKit
+
+internal final class SettingViewController: UIViewController {
+
+    let countries = ["JAPAN", "USA"]
+    let imageSize = ["Medium", "Large"]
+    
+    // TODO: 本当はLocalizable.stringsを作って文字列はすべてそこに定義し、あとから変更しやすいようにすべき
+    //       また、タイトルのラベルもstoryboard上ではなくoutletを引っ張ってきて↑の定義を設定する作りにすべき
+    
+    @IBOutlet fileprivate weak var countryLabel: UILabel!
+    @IBOutlet fileprivate weak var artworkLabel: UILabel!
+    
+    @IBOutlet private weak var dataSetPickerView: UIPickerView!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        dataSetPickerView.dataSource = self
+        dataSetPickerView.delegate = self
+        setupViews()
+    }
+
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+    }
+    
+    private func setupViews() {
+        let countryRawValue = DeviceData.countryRawValue
+        let artworkRawValue = DeviceData.imageSizeRawValue
+        countryLabel.text = countries[countryRawValue]
+        artworkLabel.text = imageSize[artworkRawValue]
+        dataSetPickerView.selectRow(countryRawValue, inComponent: 0, animated: false)
+        dataSetPickerView.selectRow(artworkRawValue, inComponent: 1, animated: false)
+    }
+}
+
+// MARK: - UIPickerViewDataSource
+extension SettingViewController: UIPickerViewDataSource {
+    
+    /// コンポーネント(スクロースする塊)がいくつあるか
+    func numberOfComponents(in pickerView: UIPickerView) -> Int {
+        // countriesとimageSize
+        return 2
+    }
+    
+    /// コンポーネントの中に何行あるか
+    func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+        switch component {
+        case 0:
+            // 国
+            return countries.count
+            
+        case 1:
+            // アートワークのサイズ
+            return imageSize.count
+            
+        default:
+            assertionFailure("ここには来ないはず")
+            return 0
+        }
+    }
+}
+
+// MARK: - UIPickerViewDelegate
+extension SettingViewController: UIPickerViewDelegate {
+    
+    /// ピッカー内のタイトル(引数のcomponentとrowを使って値を返す)
+    func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+        switch component {
+        case 0:
+            // 国
+            return countries[row]
+            
+        case 1:
+            // アートワークのサイズ
+            return imageSize[row]
+            
+        default:
+            assertionFailure("ここには来ないはず")
+            return ""
+        }
+    }
+    
+    /// ピッカーが選択された際の処理
+    func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+        switch component {
+        case 0:
+            // 国
+            DeviceData.countryRawValue = row
+            countryLabel.text = countries[row]
+            
+        case 1:
+            // アートワークのサイズ
+            DeviceData.imageSizeRawValue = row
+            artworkLabel.text = imageSize[row]
+            
+        default:
+            assertionFailure("ここには来ないはず")
+        }
+    }
+}
+
+


### PR DESCRIPTION
issue https://github.com/s10284tk/iArtwork/issues/4

デザインは適当なのであとで直すなりなんなり。
そもそも仕組みが気に入らないならこの方向ですすめるのはやめます。

一応今後の想定だと、
- [ ] 設定画面をTabBarから切り離して、NavigationControllerの右側とかに設定ボタンを置く
- [ ] 押したら画面下の方にニュッと設定のやつが出てくる。

みたいなのを想定してます。

とりあえず現状こんな感じでpicker
<img src="https://cloud.githubusercontent.com/assets/20493024/25310721/e6701d22-2826-11e7-8952-ce1acd069cfd.png" height=200>

画面下の方に出すだけなら、上のラベル要らない説すらある。