### PR TITLE
[InReview]各TableViewでの通信中にActivityIndicatorを表示する

### DIFF
--- a/iTunesArtworkiPhone.xcodeproj/project.pbxproj
+++ b/iTunesArtworkiPhone.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		A558D0BE1EACB335009BE780 /* ArtworkSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = A558D0BD1EACB335009BE780 /* ArtworkSize.swift */; };
 		A569BD611EBCB68000DB378F /* Rswift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A569BD601EBCB68000DB378F /* Rswift.framework */; };
 		A569BD621EBCB68000DB378F /* Rswift.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A569BD601EBCB68000DB378F /* Rswift.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		D8FB3E541F13E67A005E1844 /* ActivityIndicator+StartStop.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FB3E531F13E67A005E1844 /* ActivityIndicator+StartStop.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -68,6 +69,7 @@
 		A558D0BA1EACAD39009BE780 /* Country.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Country.swift; sourceTree = "<group>"; };
 		A558D0BD1EACB335009BE780 /* ArtworkSize.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArtworkSize.swift; sourceTree = "<group>"; };
 		A569BD601EBCB68000DB378F /* Rswift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Rswift.framework; path = Carthage/Build/iOS/Rswift.framework; sourceTree = "<group>"; };
+		D8FB3E531F13E67A005E1844 /* ActivityIndicator+StartStop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ActivityIndicator+StartStop.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -138,6 +140,7 @@
 				A558D0B91EACAD03009BE780 /* Model */,
 				A558D0BC1EACB0A0009BE780 /* enumeration */,
 				69AACB071E9E49AA00443DBF /* WebViewController.swift */,
+				D8FB3E531F13E67A005E1844 /* ActivityIndicator+StartStop.swift */,
 				699F0CE91E9E298700A3388F /* AppDelegate.swift */,
 				699F0CF21E9E298700A3388F /* LaunchScreen.storyboard */,
 				699F0CF51E9E298700A3388F /* Info.plist */,
@@ -295,6 +298,7 @@
 				A558D0B81EAC5BEF009BE780 /* DeviceData.swift in Sources */,
 				69B9A55C1EBCBDF000EB980F /* R.generated.swift in Sources */,
 				69AACB081E9E49AA00443DBF /* WebViewController.swift in Sources */,
+				D8FB3E541F13E67A005E1844 /* ActivityIndicator+StartStop.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iTunesArtworkiPhone/ActivityIndicator+StartStop.swift
+++ b/iTunesArtworkiPhone/ActivityIndicator+StartStop.swift
@@ -1,0 +1,25 @@
+//
+//  ActivityIndicator+StartStop.swift
+//  iTunesArtworkiPhone
+//
+//  Created by いちもつ青田 on 2017/07/11.
+//  Copyright © 2017年 piyo. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+internal struct ActivityIndicator {
+    
+    static let shared = ActivityIndicator()
+    
+    private init() { }
+    
+    func start() {
+        UIApplication.shared.isNetworkActivityIndicatorVisible = true
+    }
+    
+    func stop() {
+        UIApplication.shared.isNetworkActivityIndicatorVisible = false
+    }
+}

--- a/iTunesArtworkiPhone/MovieViewController.swift
+++ b/iTunesArtworkiPhone/MovieViewController.swift
@@ -45,6 +45,9 @@ internal final class MovieViewController: UITableViewController, UISearchBarDele
         print("押したよ")
         
         if let search = searchBar.text {
+            
+            ActivityIndicator.shared.start()
+            
             let listUrl = "http://ax.itunes.apple.com/WebObjects/MZStoreServices.woa/wa/wsSearch?"
             Alamofire.request(listUrl, parameters: [
                 "term": search,
@@ -52,6 +55,9 @@ internal final class MovieViewController: UITableViewController, UISearchBarDele
                 "entity": "movie"
                 ])
                 .responseData{ response in
+                    
+                    ActivityIndicator.shared.stop()
+                    
                     // codableでデコード
                     guard let jsonData = response.result.value else {
                         print("data is nil")

--- a/iTunesArtworkiPhone/TableViewController.swift
+++ b/iTunesArtworkiPhone/TableViewController.swift
@@ -44,6 +44,9 @@ internal final class TableViewController: UITableViewController, UISearchBarDele
         }
         
         if let search = searchBar.text {
+            
+            ActivityIndicator.shared.start()
+            
             let listUrl = "http://ax.itunes.apple.com/WebObjects/MZStoreServices.woa/wa/wsSearch?"
             Alamofire.request(listUrl, parameters: [
                 "term": search,
@@ -51,6 +54,9 @@ internal final class TableViewController: UITableViewController, UISearchBarDele
                 "entity": "musicTrack"
                 ])
                 .responseData{ response in
+                    
+                    ActivityIndicator.shared.stop()
+                    
                     // codableでデコード
                     guard let jsonData = response.result.value else {
                         print("data is nil")


### PR DESCRIPTION
掲題通り
<img src="https://user-images.githubusercontent.com/20493024/28029916-a55630da-65dc-11e7-8617-67fcd934d3e2.png" width=200>

---

各箇所で`UIApplication.shared.isNetworkActivityIndicatorVisible`に値を入れる、でも良かったんだけど、今後[こういうの](https://github.com/pkluz/PKHUD)を使いたいってなった時のために、カスタムクラスを用意しておいたほうが良いかなと思って。